### PR TITLE
Fixup references to eightyeight.

### DIFF
--- a/generators/core.go
+++ b/generators/core.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"github.com/crabmusket/gosunspec/smdx"
 	"io/ioutil"
 	"log"
 	"os"
 	"strings"
 	"text/template"
-	"github.com/eightyeight/gosunspec/smdx"
 )
 
 const preamble = `// NOTICE
@@ -44,7 +44,7 @@ func main() {
 
 	for _, file := range files {
 		if strings.HasPrefix(file.Name(), "smdx_") {
-			smdxFile, err := os.OpenFile(smdxDir + file.Name(), os.O_RDONLY, 0644)
+			smdxFile, err := os.OpenFile(smdxDir+file.Name(), os.O_RDONLY, 0644)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/xml/main.go
+++ b/xml/main.go
@@ -9,7 +9,7 @@ package xml
 
 import (
 	"encoding/xml"
-	sunspec "github.com/eightyeight/gosunspec/core"
+	sunspec "github.com/crabmusket/gosunspec/core"
 	"io"
 	"math"
 	"strconv"

--- a/xml/main_test.go
+++ b/xml/main_test.go
@@ -2,7 +2,7 @@ package xml
 
 import (
 	"bytes"
-	sunspec "github.com/eightyeight/gosunspec/core"
+	sunspec "github.com/crabmusket/gosunspec/core"
 	"testing"
 )
 

--- a/xml/models.go
+++ b/xml/models.go
@@ -1,7 +1,7 @@
 package xml
 
 import (
-	sunspec "github.com/eightyeight/gosunspec/core"
+	sunspec "github.com/crabmusket/gosunspec/core"
 )
 
 func modelFromElement(el ModelElement) sunspec.Model {


### PR DESCRIPTION
Some of the go package references still refer to the old location of the package. 

This commit updates them to refer to the current name.