### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+
+go:
+  - master
+
+script: go test -v ./impl ./memory


### PR DESCRIPTION
Example of test output: https://travis-ci.org/crabmusket/gosunspec/builds/180873966#L284

@jonseymour yea or nay?

I haven't added a badge to the readme because IMO it's awkward in branches, or if a repo gets forked (the badge points to the main repo, not the fork).

I see `cmd/checkmodels` does some sanity checks. Running it in the root directory right now gives me:
```
root@1ab9682a46f9:/go/src/github.com/crabmusket/gosunspec# ./checkmodels
63002: total block length mismatch
303: total block length mismatch
802: total block length mismatch
805: total block length mismatch
807: total block length mismatch
402: total block length mismatch
803: total block length mismatch
804: total block length mismatch
804: 0: block length inconsistent with point length: 38, 40
```
is that expected? Should we add this to the CI build?