### PR TITLE
Permit a Device to have multiple models with the same ID.

### DIFF
--- a/impl/device.go
+++ b/impl/device.go
@@ -2,14 +2,12 @@ package impl
 
 import (
 	"errors"
-	"fmt"
 	"github.com/crabmusket/gosunspec"
 	"github.com/crabmusket/gosunspec/spi"
 )
 
 var (
-	errWrongType      = errors.New("supplied model has wrong implementation type")
-	errDuplicateModel = errors.New("duplicate model")
+	errWrongType = errors.New("supplied model has wrong implementation type")
 )
 
 type device struct {
@@ -17,21 +15,19 @@ type device struct {
 	models []*model
 }
 
-func (d *device) Model(id sunspec.ModelId) (sunspec.Model, error) {
-	for _, m := range d.models {
-		if m.Id() == id {
-			return m, nil
-		}
-	}
-	return nil, fmt.Errorf("invalid model id: ", id)
-}
-
 func (d *device) MustModel(id sunspec.ModelId) sunspec.Model {
-	if m, err := d.Model(id); err != nil {
-		panic(err)
-	} else {
-		return m
+	r := []sunspec.Model{}
+	d.Do(func(m sunspec.Model) {
+		if m.Id() == id {
+			r = append(r, m)
+		}
+	})
+	if len(r) < 1 {
+		panic(sunspec.ErrNoSuchModel)
+	} else if len(r) > 1 {
+		panic(sunspec.ErrTooManyModels)
 	}
+	return r[0]
 }
 
 func (d *device) Do(f func(b sunspec.Model)) {
@@ -48,11 +44,6 @@ func (d *device) DoWithSPI(f func(b spi.ModelSPI)) {
 
 func (d *device) AddModel(m spi.ModelSPI) error {
 	if r, ok := m.(*model); ok {
-		for _, e := range d.models {
-			if e.Id() == m.Id() {
-				return errDuplicateModel
-			}
-		}
 		d.models = append(d.models, r)
 	} else if !ok {
 		return errWrongType

--- a/memory/data_test.go
+++ b/memory/data_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/crabmusket/gosunspec/models/model304"
 	"github.com/crabmusket/gosunspec/models/model401"
 	"github.com/crabmusket/gosunspec/models/model501"
+	"github.com/crabmusket/gosunspec/models/model502"
 	"github.com/crabmusket/gosunspec/models/model63001"
 	"github.com/crabmusket/gosunspec/typelabel"
 )
@@ -73,6 +74,8 @@ func init() {
 		AddRepeat(model401.ModelID).
 		AddRepeat(model401.ModelID).
 		AddModel(model501.ModelID).
+		AddModel(model502.ModelID).
+		AddModel(model502.ModelID).
 		AddModel(model63001.ModelID).
 		AddRepeat(model63001.ModelID).
 		Build()

--- a/memory/memory.go
+++ b/memory/memory.go
@@ -229,11 +229,16 @@ func (b *builder) AddModel(id sunspec.ModelId) SlabBuilder {
 
 // Add a repeat to the specified model
 func (b *builder) AddRepeat(id sunspec.ModelId) SlabBuilder {
-	if m, err := b.device.Model(id); err != nil {
-		b.record(err)
-	} else {
-		b.record(m.(spi.ModelSPI).AddRepeat())
-	}
+	// Note: this assumes all models of the same identifier
+	// in the same address space have the same number of repeats
+	// In principle, this might not be true. In practice,
+	// it is likely to be true. We can live with the simplification
+	// for now.
+	b.device.Do(func(m sunspec.Model) {
+		if m.Id() == id {
+			b.record(m.(spi.ModelSPI).AddRepeat())
+		}
+	})
 	return b
 }
 

--- a/memory/memory_test.go
+++ b/memory/memory_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/crabmusket/gosunspec"
 	"github.com/crabmusket/gosunspec/models/model1"
 	"github.com/crabmusket/gosunspec/models/model101"
+	"github.com/crabmusket/gosunspec/models/model502"
 	"testing"
 )
 
@@ -49,6 +50,7 @@ func TestSlab(t *testing.T) {
 			b.MustPoint(model1.SN).SetStringValue("abcde")
 			b.Write(model1.SN)
 		}
+
 	}
 
 	// reopen the slab for reading
@@ -156,8 +158,28 @@ func TestComplexSlab(t *testing.T) {
 		})
 	})
 
-	expected := 168
+	expected := 210
 	if count != expected {
 		t.Fatalf("unexpected number of points. actual: %d, expected: %d", count, expected)
+	}
+}
+
+func TestMustModelFailsWithManyModels(t *testing.T) {
+
+	d, _ := Open(ComplexNonZeroSlab)
+
+	err := func() (err error) {
+		defer func() {
+			r := recover()
+			if e, ok := r.(error); ok {
+				err = e
+			}
+			panic(r)
+		}()
+		d.MustModel(model502.ModelID)
+		return nil
+	}
+	if err == nil {
+		t.Fatalf("error expected")
 	}
 }

--- a/sunspec.go
+++ b/sunspec.go
@@ -18,8 +18,10 @@ import (
 )
 
 var (
-	ErrNoSuchBlock = errors.New("no such block")
-	ErrNoSuchPoint = errors.New("no such point")
+	ErrNoSuchBlock   = errors.New("no such block")
+	ErrNoSuchModel   = errors.New("no such model")
+	ErrTooManyModels = errors.New("too many models")
+	ErrNoSuchPoint   = errors.New("no such point")
 )
 
 // ModelId is the type of model identifiers used with the Device.Model and Device.MustModel
@@ -92,10 +94,9 @@ type Array interface {
 // A Device is a collection of Models that provides an uniform abstraction of
 // physical devices of various kinds (Modbus, memory, XML documents)
 type Device interface {
-	// Model answers the first model with the matching identifier, or returns an error otherwise
-	Model(id ModelId) (Model, error) // Answer the specified model instance or nil
-
-	// MustModel answers the first model specified by id, or panics otherwise
+	// MustModel answers the first and only model specified by id, or panics otherwise
+	// This method should not be used unless it is known for sure that the device
+	// does not have multiple models with the specified id.
 	MustModel(id ModelId) Model
 
 	// Do iterates over all the models supported by the device


### PR DESCRIPTION
The SunSpec Model Data Interchange specification (12021) permits
a single device to have multiple instances of a model.

The API previously had this method:

```
type Device interface {
    Model(id) (Model, error)
}

```
which contained an implicit assumption that there was only one
model of each type per device.

So, now we remove the Model(id) method and instead require the programmer
to assert there is exactly one model of the specified type or cope
with multiple models by using the Do() function instead.

Signed-off-by: Jon Seymour <jon@wildducktheories.com>