### PR TITLE
impl: extend set of implied points

### DIFF
--- a/impl/funcs.go
+++ b/impl/funcs.go
@@ -1,0 +1,31 @@
+package impl
+
+import (
+	"github.com/crabmusket/gosunspec/spi"
+	"github.com/crabmusket/gosunspec/typelabel"
+)
+
+// scaleFactorFirstOrder defines the sort order for points in which scale factors appear before non-scale factors
+// and everything is sorted in modbus offset order. Points need to be written into the model in the order
+// defined by this order so as to guarantee that the non-scale factor points are not invalidated.
+type scaleFactorFirstOrder []spi.PointSPI
+
+func (o scaleFactorFirstOrder) Len() int {
+	return len(o)
+}
+
+func (o scaleFactorFirstOrder) Less(i, j int) bool {
+	p1 := o[i]
+	p2 := o[j]
+	if p1.Type() == typelabel.ScaleFactor && p2.Type() != typelabel.ScaleFactor {
+		return true
+	} else if p1.Type() != typelabel.ScaleFactor && p2.Type() == typelabel.ScaleFactor {
+		return false
+	} else {
+		return p1.Offset() < p2.Offset()
+	}
+}
+
+func (o scaleFactorFirstOrder) Swap(i, j int) {
+	o[i], o[j] = o[j], o[i]
+}


### PR DESCRIPTION
The previous implementation led to situations where Block.Read("A") followed by
Block.Read("B") would cause point A to be (surprisingly) invalidated after
the second Read occurred in the case where "A" and "B" are related to the same scale factor
point "C".

With this change, the second read for "B" will imply the read of "C"
(previous behaviour) but now also "A". This ensures that points that were
previously valid remain valid although perhaps with new values.

Of course, it would always be more efficient to only do block.Read("A", "B")
(which would also read "C") but to know this the programmer needs to keep
track of the transitive dependency between "A" and "B" which may not always
be convenient to do.