### PR TITLE
Add a Device.Collect method.

### DIFF
--- a/sunspec.go
+++ b/sunspec.go
@@ -101,6 +101,34 @@ type Device interface {
 
 	// Do iterates over all the models supported by the device
 	Do(func(m Model))
+
+	// Collects the subset of models that match the filter specified.
+	//
+	// for example:
+	//     if m, err := ExactlyOneModel(d.Collect(SameModelId(model101.ModelID))); err == nil {
+	//          // operate on the one and only model m
+	//     }
+	Collect(func(m Model) bool) []Model
+}
+
+// A filter that can be used with Device.Collect to select a subset
+// of the models that have the model id specified.
+func SameModelId(id ModelId) func(m Model) bool {
+	return func(m Model) bool {
+		return id == m.Id()
+	}
+}
+
+// ExactlyOneModel returns a model iff the slice contains
+// exactly one model or an error otherwise.
+func ExactlyOneModel(models []Model) (Model, error) {
+	if len(models) > 1 {
+		return nil, ErrTooManyModels
+	} else if len(models) < 1 {
+		return nil, ErrNoSuchModel
+	} else {
+		return models[0], nil
+	}
 }
 
 // A Model is a collection of Blocks which represents a relocatable


### PR DESCRIPTION
Add a method that provides easier access to models of a specific id.

Now we can work with models of a specific id with:

```
for _, m := range d.Collect(sunspec.SameModelId(model101.ModelID)) {
        ...
}
```

There is also an ExactlyOneModel([]Model) (Model, error) method which checks that the slice contains exactly one model or returns an error otherwise. For an example, see the device.MustModel() method in the impl package.

@crabmusket hopefully this addresses you concern about accessing a specific model

Signed-off-by: Jon Seymour <jon@wildducktheories.com>