### PR TITLE
Abstract out AddressLayout and AddressSpace function.

### DIFF
--- a/impl/block.go
+++ b/impl/block.go
@@ -38,6 +38,18 @@ func (b *block) Do(f func(p sunspec.Point)) {
 	}
 }
 
+func (b *block) DoScaleFactorsFirst(f func(p sunspec.Point)) {
+	once := func(filter func(pe smdx.PointElement) bool) {
+		for _, pe := range b.smdx.Points {
+			if filter(pe) {
+				f(b.points[pe.Id])
+			}
+		}
+	}
+	once(func(pe smdx.PointElement) bool { return pe.Type == typelabel.ScaleFactor })
+	once(func(pe smdx.PointElement) bool { return pe.Type != typelabel.ScaleFactor })
+}
+
 func (b *block) Read(pointIds ...string) error {
 	return b.driver.Read(b, pointIds...)
 }

--- a/impl/factory.go
+++ b/impl/factory.go
@@ -85,13 +85,7 @@ func NewContiguousModel(me *smdx.ModelElement, bound uint16, phys spi.Driver) sp
 // determines the number of repeats.
 func NewModel(me *smdx.ModelElement, nr int, driver spi.Driver) spi.ModelSPI {
 
-	blocks := []*block{}
-	for x, _ := range me.Blocks {
-		blocks = append(blocks, newBlock(&me.Blocks[x], driver))
-		if nr == 0 {
-			break // don't put in the first repeat
-		}
-	}
+	blocks := []*block{newBlock(&me.Blocks[0], driver)}
 
 	m := &model{
 		smdx:   me,
@@ -99,7 +93,7 @@ func NewModel(me *smdx.ModelElement, nr int, driver spi.Driver) spi.ModelSPI {
 		blocks: blocks,
 	}
 
-	for nr > 1 {
+	for nr > 0 {
 		nr--
 		m.AddRepeat()
 	}

--- a/layout/layout.go
+++ b/layout/layout.go
@@ -1,0 +1,30 @@
+package layout
+
+import (
+	"errors"
+	"github.com/crabmusket/gosunspec/spi"
+)
+
+const (
+	SunSpec = 0x53756e53 // "SunS" - marker bytes used to confirm that a region of Modbus address space is laid out according to SunSpec standards
+)
+
+var (
+	ErrNotSunspecDevice = errors.New("not a SunSpec device") // if the Modbus address space doesn't contain the expected marker bytes
+	ErrShortRead        = errors.New("short read")           // if an attempt to read from the Modbus addess space returns fewer bytes than expected
+)
+
+// AddressSpaceDriver abstracts the behaviour of drivers that are mapped onto a linear address space,
+// so that the same AddressSpaceLayout implementation can be used across different linear
+// address space implementations (e.g. memory & Modbus)
+type AddressSpaceDriver interface {
+	spi.Driver
+	BaseOffsets() []uint16
+	ReadWords(address uint16, length uint16) ([]byte, error)
+}
+
+// AddressSpaceLayout encapsulates an algorithm for scanning an address space for devices. There are
+// two implementations - layout.SunSpecLayout and layout.RawLayout.
+type AddressSpaceLayout interface {
+	Open(a AddressSpaceDriver) (spi.ArraySPI, error)
+}

--- a/layout/raw.go
+++ b/layout/raw.go
@@ -1,0 +1,106 @@
+package layout
+
+import (
+	"encoding/xml"
+	"errors"
+	"github.com/crabmusket/gosunspec"
+	"github.com/crabmusket/gosunspec/impl"
+	"github.com/crabmusket/gosunspec/smdx"
+	"github.com/crabmusket/gosunspec/spi"
+	"io"
+	"log"
+)
+
+var ErrAbsoluteAddress = errors.New("The absolute address for block cannot be calculated from the layout.")
+
+// RawModel layout specifies the model ID used to describe a block of memory at an Address
+type RawModelLayout struct {
+	XMLName xml.Name        `xml:"model"`
+	ModelId sunspec.ModelId `xml:"id,attr"`
+	Address *uint16         `xml:"addr,attr,omitempty"`
+	Repeats *uint16         `xml:"repeats,attr,omitempty"`
+}
+
+// RawDeviceLayout is a slice of RawModelLayouts
+type RawDeviceLayout struct {
+	XMLName xml.Name         `xml:"device"`
+	Models  []RawModelLayout `xml:"model"`
+}
+
+// RawLayout is the type of layout used for non-SunSpec address spaces. This means
+// arbitrary Modbus address spaces where blocks are located at arbitrary addresses
+// in an address space and neither the model ID nor the block length are encoded
+// in the address space itself.
+//
+// The intent of RawLayout is to allow the sunspec API to be used effectively
+// with non-SunSpec address spaces, assuming the work has been done to
+// markup the address space with SMDX models and an XML document that maps
+// addresses to model ids.
+type RawLayout struct {
+	XMLName xml.Name          `xml:"layout"`
+	Devices []RawDeviceLayout `xml:"device"`
+}
+
+// FromLayoutXML reads a layout description from an XML stream.
+func FromLayoutXML(reader io.Reader) (*RawLayout, error) {
+	decoder := xml.NewDecoder(reader)
+	layout := &RawLayout{}
+	return layout, decoder.Decode(layout)
+}
+
+// Opens an address space with a raw layout.
+func (s *RawLayout) Open(driver AddressSpaceDriver) (spi.ArraySPI, error) {
+
+	array := impl.NewArray()
+	dev := impl.NewDevice()
+
+	// Build up model
+
+	var nextAddr *uint16
+
+	for _, d := range s.Devices {
+		for _, m := range d.Models {
+
+			me := smdx.GetModel(uint16(m.ModelId))
+			if me != nil {
+
+				modelLength := me.Blocks[0].Length
+				r := uint16(0)
+				if m.Repeats != nil && *m.Repeats > 0 {
+					r = *m.Repeats
+					if len(me.Blocks) > 1 {
+						modelLength += me.Blocks[1].Length * r
+					} else {
+						modelLength += me.Blocks[0].Length * r
+					}
+				}
+
+				model := impl.NewContiguousModel(me, modelLength, driver)
+
+				// set anchors on the blocks
+				var offset uint16
+
+				if m.Address != nil {
+					offset = *m.Address
+				} else if nextAddr != nil {
+					offset = *nextAddr
+				} else {
+					return nil, ErrAbsoluteAddress
+				}
+
+				model.Do(spi.WithBlockSPI(func(b spi.BlockSPI) {
+					b.SetAnchor(uint16(offset))
+					offset += b.Length()
+				}))
+
+				nextAddr = &offset
+				dev.AddModel(model)
+			} else {
+				nextAddr = nil
+				log.Printf("unrecognised model identifier skipped: %d\n", m.ModelId)
+			}
+		}
+		array.AddDevice(dev)
+	}
+	return array, nil
+}

--- a/layout/raw_test.go
+++ b/layout/raw_test.go
@@ -1,0 +1,158 @@
+package layout_test
+
+import (
+	"bytes"
+	"encoding/hex"
+	"github.com/crabmusket/gosunspec"
+	"github.com/crabmusket/gosunspec/layout"
+	"github.com/crabmusket/gosunspec/memory"
+	"github.com/crabmusket/gosunspec/spi"
+	"log"
+	"sync"
+	"testing"
+)
+
+var xml = `
+<layout>
+	<device>
+		<model id="1"     addr="4" />
+		<model id="11"    addr="72" /> 
+		<model id="101"   addr="87" />
+		<model id="304"   addr="139" repeats="2"/>
+		<model id="401"   addr="159" repeats="2"/>
+		<model id="501"   addr="191" />
+		<model id="502"   addr="224" />
+		<model id="502"   addr="254" />
+		<model id="63001" addr="284" repeats="1"/>
+	</device>
+</layout>
+`
+
+func TestRawLayoutReading(t *testing.T) {
+	blank := make([]byte, len(memory.ComplexEmptySlab))
+	copy(blank, memory.ComplexEmptySlab)
+
+	defer func() {
+		if e := recover(); e != nil {
+			log.Printf("dump:\n %+v \n %+v", hex.Dump(blank), hex.Dump(memory.ComplexNonZeroSlab))
+			panic(e)
+		}
+	}()
+
+	mem, err := memory.Open(blank)
+	if err != nil {
+		t.Fatal(err)
+	}
+	layout, err := layout.FromLayoutXML(bytes.NewReader([]byte(xml)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := memory.OpenWithLayout(memory.ComplexNonZeroSlab, layout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chD := make(chan sunspec.Device)
+	chM := make(chan sunspec.Model)
+	chB := make(chan sunspec.Block)
+	chP := make(chan sunspec.Point)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	test304 := func(n string) func(d sunspec.Device) {
+		return func(d sunspec.Device) {
+			m := d.MustModel(304)
+			{
+				expected := uint16(m.(spi.ModelSPI).Blocks() * 6)
+				actual := uint16(m.(spi.ModelSPI).Length())
+				if actual != expected {
+					t.Fatalf("model 304 (%s) has inconsistent model lemgth. actual=%d, expected=%d\n", n, actual, expected)
+				}
+
+			}
+			{
+				expected := uint16(3)
+				actual := uint16(m.Blocks())
+				if actual != expected {
+					t.Fatalf("model 304 (%s) has wrong number of blocks. actual=%d, expected=%d\n", n, actual, expected)
+				}
+			}
+		}
+	}
+	test401 := func(n string) func(d sunspec.Device) {
+		return func(d sunspec.Device) {
+			m := d.MustModel(401)
+			{
+				expected := uint16(3)
+				actual := uint16(m.Blocks())
+				if actual != expected {
+					t.Fatalf("model 401 (%s) has wrong number of blocks. actual=%d, expected=%d\n", n, actual, expected)
+				}
+			}
+			{
+				expected := uint16((m.(spi.ModelSPI).Blocks()-1)*8 + 14)
+				actual := uint16(m.(spi.ModelSPI).Length())
+				if actual != expected {
+					t.Fatalf("model 401 (%s) has inconsistent model lemgth. actual=%d, expected=%d\n", n, actual, expected)
+				}
+			}
+		}
+	}
+
+	mem.Do(test304("mem"))
+	raw.Do(test304("raw"))
+	mem.Do(test401("mem"))
+	raw.Do(test401("raw"))
+
+	go func() {
+		mem.Do(func(d sunspec.Device) {
+			d1 := <-chD
+			if d1 != nil {
+				d.Do(func(m sunspec.Model) {
+					_ = <-chM
+					bn := 0
+					m.Do(func(b sunspec.Block) {
+						b1 := <-chB
+						_ = b1
+						b.DoScaleFactorsFirst(func(p sunspec.Point) {
+							p1 := <-chP
+							if p1.Error() == nil {
+								p.SetValue(p1.Value())
+							}
+						})
+						bn++
+						b.Write()
+					})
+				})
+			}
+		})
+		wg.Done()
+	}()
+
+	raw.Do(func(d sunspec.Device) {
+		chD <- d
+		d.Do(func(m sunspec.Model) {
+			chM <- m
+			bn := 0
+			m.Do(func(b sunspec.Block) {
+				_ = b.Read()
+				chB <- b
+				b.DoScaleFactorsFirst(func(p sunspec.Point) {
+					chP <- p
+				})
+				bn++
+			})
+		})
+	})
+	close(chD)
+
+	wg.Wait()
+
+	for i, b := range blank {
+		if b != memory.ComplexNonZeroSlab[i] {
+			t.Fatalf("mismatch at position 0x%04x:\n %+v \n %+v", i, hex.Dump(blank), hex.Dump(memory.ComplexNonZeroSlab))
+		}
+	}
+
+}

--- a/layout/sunspec.go
+++ b/layout/sunspec.go
@@ -1,0 +1,84 @@
+package layout
+
+import (
+	"encoding/binary"
+	"github.com/crabmusket/gosunspec/impl"
+	"github.com/crabmusket/gosunspec/models/model1"
+	"github.com/crabmusket/gosunspec/smdx"
+	"github.com/crabmusket/gosunspec/spi"
+	"log"
+)
+
+// SunspecLayout is the type of layout that understands the SunSpec layout conventions.
+type SunSpecLayout struct {
+}
+
+// Open scans the supplied address space and returns an array of the
+// devices found.
+func (s *SunSpecLayout) Open(a AddressSpaceDriver) (spi.ArraySPI, error) {
+
+	// Attempt to locate SunSpec register within modbus address space.
+
+	baseRange := a.BaseOffsets()
+	base := uint16(0xffff)
+	for _, b := range baseRange {
+		if id, err := a.ReadWords(b, 2); err != nil {
+			continue
+		} else if binary.BigEndian.Uint32(id) != SunSpec {
+			continue
+		} else {
+			base = b
+			break
+		}
+	}
+	if base == 0xffff {
+		return nil, ErrNotSunspecDevice
+	}
+
+	phys := a
+	array := impl.NewArray()
+	dev := impl.NewDevice()
+
+	// Build up model
+
+	offset := uint16(2) // number of 16 bit registers
+	for {
+		if bytes, err := a.ReadWords(base+offset, 2); err != nil {
+			return nil, err
+		} else if len(bytes) < 4 {
+			return nil, ErrShortRead
+		} else {
+			modelId := binary.BigEndian.Uint16(bytes)
+			modelLength := binary.BigEndian.Uint16(bytes[2:])
+
+			if modelId == 0xffff {
+				break
+			}
+
+			me := smdx.GetModel(modelId)
+			if me != nil {
+
+				if modelId == uint16(model1.ModelID) {
+					dev = impl.NewDevice()
+					array.(spi.ArraySPI).AddDevice(dev)
+				}
+
+				m := impl.NewContiguousModel(me, modelLength, phys)
+
+				// set anchors on the blocks
+
+				blockOffset := offset + 2
+				m.Do(spi.WithBlockSPI(func(b spi.BlockSPI) {
+					b.SetAnchor(uint16(base + blockOffset))
+					blockOffset += b.Length()
+				}))
+				dev.AddModel(m)
+			} else {
+				log.Printf("unrecognised model identifier skipped @ offset: %d, %d\n", modelId, offset)
+			}
+			offset += 2 + modelLength
+		}
+	}
+	return array, nil
+
+}

--- a/memory/memory.go
+++ b/memory/memory.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"github.com/crabmusket/gosunspec"
 	"github.com/crabmusket/gosunspec/impl"
+	"github.com/crabmusket/gosunspec/layout"
 	"github.com/crabmusket/gosunspec/models/model1"
 	"github.com/crabmusket/gosunspec/smdx"
 	"github.com/crabmusket/gosunspec/spi"
@@ -21,6 +22,7 @@ var (
 )
 
 type memoryDriver struct {
+	buffer []byte
 }
 
 func (d *memoryDriver) iterator(b spi.BlockSPI, pointIds ...string) func(f func(buffer []byte, p spi.PointSPI) error) error {
@@ -54,7 +56,7 @@ func (d *memoryDriver) iterator(b spi.BlockSPI, pointIds ...string) func(f func(
 			}))
 		}
 
-		buffer := b.Anchor().([]byte)
+		buffer := d.buffer[b.Anchor().(uint16)*2:]
 
 		for _, p := range points {
 			if p.Offset()+p.Length() > b.Length() {
@@ -80,7 +82,7 @@ func (d *memoryDriver) Read(b spi.BlockSPI, pointIds ...string) error {
 		return err
 	} else {
 		var firstErr error
-		buffer := b.Anchor().([]byte)
+		buffer := d.buffer[b.Anchor().(uint16)*2:]
 		for _, p := range points {
 			if p.Offset()+p.Length() > b.Length() {
 				err := errBufferTooShort
@@ -112,53 +114,25 @@ func (d *memoryDriver) Write(b spi.BlockSPI, pointIds ...string) error {
 	})
 }
 
+func (d *memoryDriver) ReadWords(a uint16, l uint16) ([]byte, error) {
+	return d.buffer[a*2 : (a+l)*2], nil
+}
+
+func (d *memoryDriver) BaseOffsets() []uint16 {
+	return []uint16{0}
+}
+
 // Open a memory mapped Sunspec device from the specified
 // byte slice or return an error if this cannot be done.
 func Open(bytes []byte) (sunspec.Array, error) {
-	d := &memoryDriver{}
-	arr := impl.NewArray()
-	var dev spi.DeviceSPI
-	if len(bytes) < len(eyeCatcher) {
-		return nil, errBadEyeCatcher
-	}
-	for i, b := range eyeCatcher {
-		if bytes[i] != b {
-			return nil, errBadEyeCatcher
-		}
-	}
-	offset := 4
-	for {
-		if offset+4 > len(bytes) {
-			return nil, errBufferTooShort
-		}
-		modelId := binary.BigEndian.Uint16(bytes[offset:])
-		length := binary.BigEndian.Uint16(bytes[offset+2:])
-		if offset+4+int(length)*2 > len(bytes) {
-			return nil, errBufferTooShort
-		}
-		if modelId == 0xffff {
-			break
-		}
-		if modelId == uint16(model1.ModelID) || dev == nil {
-			dev = impl.NewDevice()
-			arr.AddDevice(dev)
-		}
-		me := smdx.GetModel(uint16(modelId))
-		if me != nil {
-			m := impl.NewContiguousModel(me, length, d)
+	return OpenWithLayout(bytes, &layout.SunSpecLayout{})
+}
 
-			// set anchors on the blocks
-
-			blockOffset := offset + 4
-			m.Do(spi.WithBlockSPI(func(b spi.BlockSPI) {
-				b.SetAnchor(bytes[blockOffset : blockOffset+int(b.Length()*2)])
-				blockOffset += int(b.Length()) * 2
-			}))
-			dev.AddModel(m)
-		}
-		offset += 4 + int(length)*2
-	}
-	return arr, nil
+// Open a memory mapped Sunspec device from the specified
+// byte slice, using the layout specified to match regions
+// of the slice to particular devices and models.
+func OpenWithLayout(bytes []byte, l layout.AddressSpaceLayout) (sunspec.Array, error) {
+	return l.Open(&memoryDriver{buffer: bytes})
 }
 
 // SlabBuilder creates a slab of memory (actually a byte slice)

--- a/memory/memory_test.go
+++ b/memory/memory_test.go
@@ -181,13 +181,13 @@ func TestComplexSlab(t *testing.T) {
 
 	{
 		actual := d.MustModel(model304.ModelID).Blocks()
-		expected := 2
+		expected := 3
 		if actual != expected {
 			t.Fatalf("wrong number of blocks. actual: %d, expected: %d", actual, expected)
 		}
 	}
 
-	expected := 213
+	expected := 216
 	if count != expected {
 		t.Fatalf("unexpected number of points. actual: %d, expected: %d", count, expected)
 	}
@@ -221,7 +221,7 @@ func TestTwoDeviceSlab(t *testing.T) {
 		})
 	})
 
-	expected := 426
+	expected := 432
 	if count != expected {
 		t.Fatalf("unexpected number of points. actual: %d, expected: %d", count, expected)
 	}

--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -1,15 +1,11 @@
 package modbus
 
 import (
-	"encoding/binary"
 	"errors"
 	"github.com/crabmusket/gosunspec"
-	"github.com/crabmusket/gosunspec/impl"
-	"github.com/crabmusket/gosunspec/models/model1"
-	"github.com/crabmusket/gosunspec/smdx"
+	"github.com/crabmusket/gosunspec/layout"
 	"github.com/crabmusket/gosunspec/spi"
 	"github.com/goburrow/modbus"
-	"log"
 )
 
 const (
@@ -18,7 +14,6 @@ const (
 
 var (
 	ErrNotSunspecDevice = errors.New("not a SunSpec device") // if the Modbus address space doesn't contain the expected marker bytes
-	ErrShortRead        = errors.New("short read")           // if an attempt to read from the Modbus addess space returns fewer bytes than expected
 )
 
 // Open uses the Modbus connection provided by client to connect
@@ -26,74 +21,24 @@ var (
 // one or more SunSpec devices and a reference to
 // a sunspec.Array that provides access to these devices is returned.
 func Open(client modbus.Client) (sunspec.Array, error) {
+	return OpenWithLayout(client, &layout.SunSpecLayout{})
+}
 
-	// Attempt to locate SunSpec register within modbus address space.
-
-	baseRange := []uint16{40000, 50000, 0}
-	base := uint16(0xffff)
-	for _, b := range baseRange {
-		if id, err := client.ReadHoldingRegisters(b, 2); err != nil {
-			continue
-		} else if binary.BigEndian.Uint32(id) != SunSpec {
-			continue
-		} else {
-			base = b
-			break
-		}
-	}
-	if base == 0xffff {
-		return nil, ErrNotSunspecDevice
-	}
-
-	phys := &modbusDriver{client: client}
-	array := impl.NewArray()
-	dev := impl.NewDevice()
-
-	// Build up model
-
-	offset := uint16(2) // number of 16 bit registers
-	for {
-		if bytes, err := client.ReadHoldingRegisters(base+offset, 2); err != nil {
-			return nil, err
-		} else if len(bytes) < 4 {
-			return nil, ErrShortRead
-		} else {
-			modelId := binary.BigEndian.Uint16(bytes)
-			modelLength := binary.BigEndian.Uint16(bytes[2:])
-
-			if modelId == 0xffff {
-				break
-			}
-
-			me := smdx.GetModel(modelId)
-			if me != nil {
-
-				if modelId == uint16(model1.ModelID) {
-					dev = impl.NewDevice()
-					array.(spi.ArraySPI).AddDevice(dev)
-				}
-
-				m := impl.NewContiguousModel(me, modelLength, phys)
-
-				// set anchors on the blocks
-
-				blockOffset := offset + 2
-				m.Do(spi.WithBlockSPI(func(b spi.BlockSPI) {
-					b.SetAnchor(uint16(base + blockOffset))
-					blockOffset += b.Length()
-				}))
-				dev.AddModel(m)
-			} else {
-				log.Printf("unrecognised model identifier skipped @ offset: %d, %d\n", modelId, offset)
-			}
-			offset += 2 + modelLength
-		}
-	}
-	return array, nil
+// Open a Modbus connection using the client specified and the layout specified. layout specified.
+func OpenWithLayout(client modbus.Client, l layout.AddressSpaceLayout) (sunspec.Array, error) {
+	return l.Open(&modbusDriver{client: client})
 }
 
 type modbusDriver struct {
 	client modbus.Client
+}
+
+func (m *modbusDriver) ReadWords(address uint16, length uint16) ([]byte, error) {
+	return m.client.ReadHoldingRegisters(address, length)
+}
+
+func (m *modbusDriver) BaseOffsets() []uint16 {
+	return []uint16{40000, 50000, 0}
 }
 
 // Write out the points in exactly the order specified, coalescing

--- a/modbus/modbus_test.go
+++ b/modbus/modbus_test.go
@@ -48,7 +48,7 @@ func TestComplexSlab(t *testing.T) {
 					})
 				})
 
-				expected := 213
+				expected := 216
 				if count != expected {
 					t.Fatalf("unexpected number of points. actual: %d, expected: %d", count, expected)
 				}
@@ -109,7 +109,7 @@ func TestComplexSlabStaggered(t *testing.T) {
 				})
 
 			})
-			expected := 213
+			expected := 216
 			if count != expected {
 				t.Fatalf("unexpected number of points. actual: %d, expected: %d", count, expected)
 			}

--- a/sunspec.go
+++ b/sunspec.go
@@ -169,6 +169,13 @@ type Block interface {
 	// Do iterates over all the points in the block in the specification order.
 	Do(func(p Point))
 
+	// Do iterates over all the scale factor points, then the non-scale factor
+	// points. Both groups are processed in specification order. This method
+	// is useful when multiple points in the block need to be updated and the
+	// set of points to be updated includes both scale factor points and
+	// value points related to the scale factor points.
+	DoScaleFactorsFirst(func(p Point))
+
 	// Read the registers implied by the specified pointIds from the physical
 	// device. If no pointIds are specified, then all the points in the block
 	// are read.

--- a/xml/driver.go
+++ b/xml/driver.go
@@ -100,7 +100,11 @@ func OpenDevice(dx *DeviceElement) (sunspec.Device, error) {
 				max = px.Index
 			}
 		}
-		m := impl.NewModel(smdx, int(max), xp)
+		repeats := int(max)
+		if len(smdx.Blocks) == 1 {
+			repeats -= 1
+		}
+		m := impl.NewModel(smdx, repeats, xp)
 		if err := d.AddModel(m); err != nil {
 			return nil, err
 		} else {
@@ -206,12 +210,11 @@ func CopyDevice(d sunspec.Device) (sunspec.Device, *DeviceElement) {
 	d.Do(func(m sunspec.Model) {
 		smdx := smdx.GetModel(uint16(m.Id()))
 
-		mc := impl.NewModel(smdx, m.Blocks(), xp)
+		repeatOnly := m.Blocks() > 1 && len(smdx.Blocks) == 1
+		mc := impl.NewModel(smdx, m.Blocks()-1, xp)
 		mx := newModelElement(m.Id())
 
 		dx.Models = append(dx.Models, mx)
-
-		repeatOnly := m.Blocks() > 1 && len(smdx.Blocks) == 1
 
 		for i := 0; i < m.Blocks(); i++ {
 			b := m.MustBlock(i).(spi.BlockSPI)

--- a/xml/driver_test.go
+++ b/xml/driver_test.go
@@ -46,7 +46,7 @@ func TestCopyDevice(t *testing.T) {
 		})
 	})
 
-	expected := 426
+	expected := 432
 	if count != expected {
 		t.Fatalf("unexpected number of points. actual: %d, expected: %d", count, expected)
 	}


### PR DESCRIPTION
The end goal of these changes is to support non-SunSpec address
spaces with the same API. The reason is that in any practical SunSpec
work, it will be necessary to access parts of the address space
that is not layed out with SunSpec conventions - usually legacy, vendor
specfic address maps that have not been standardised by SunSpec and
have not been developed in accordance with SunSpec design guidelines
(e.g. they are not self-describing).

Now, while we could create a whole different API for this purpose, but this API
already does a vast majority of the heavy lifting with regard to meta-data
management and data marshalling, so it seems sensible to enable re-use of this work.

Signed-off-by: Jon Seymour <jon@wildducktheories.com>