### PR TITLE
sunspecio: a command to read from or write to sunspec address spaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ language: go
 go:
   - master
 
-script: go test -v ./impl ./memory ./xml
+script: go test -v ./impl ./memory ./xml ./modbus ./layout

--- a/cmd/sunspecio/main.go
+++ b/cmd/sunspecio/main.go
@@ -1,0 +1,247 @@
+// This package contains a command that allows an input address space to be copied into a
+// similarly shaped output address space.
+//
+// For examople:
+//
+//     sunspecio --in:type=modbus --in:device=/dev/ttyS0 --in:speed=38400 --out:type=xml
+//
+// will read the Sunspec address space in the Modbus device connected to the specified serial port
+// and copy it into an xml document which is written to stdout.
+package main
+
+import (
+	xmlencoding "encoding/xml"
+	"flag"
+	"github.com/crabmusket/gosunspec"
+	"github.com/crabmusket/gosunspec/layout"
+	"github.com/crabmusket/gosunspec/modbus"
+	_ "github.com/crabmusket/gosunspec/models"
+	"github.com/crabmusket/gosunspec/smdx"
+	"github.com/crabmusket/gosunspec/xml"
+	modbusapi "github.com/goburrow/modbus"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"time"
+)
+
+func openModbus(device string, config func(handler *modbusapi.RTUClientHandler)) (modbusapi.Client, func(), error) {
+
+	handler := modbusapi.NewRTUClientHandler(device)
+
+	handler.BaudRate = 38400
+	handler.DataBits = 8
+	handler.Parity = "N"
+	handler.StopBits = 1
+	handler.SlaveId = 1
+	handler.Timeout = 5 * time.Second
+
+	config(handler)
+
+	err := handler.Connect()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	client := modbusapi.NewClient(handler)
+
+	return client, func() { handler.Close() }, nil
+}
+
+func encode(w io.Writer, i interface{}) error {
+	encoder := xmlencoding.NewEncoder(w)
+	encoder.Indent("", "   ")
+	err := encoder.Encode(i)
+	return err
+}
+
+func readLayout(n string) layout.AddressSpaceLayout {
+	if n != "" {
+		if f, err := os.Open(n); err != nil {
+			log.Fatal(err)
+		} else {
+			defer f.Close()
+			obj := &layout.RawLayout{}
+			if err := xmlencoding.NewDecoder(f).Decode(obj); err != nil {
+				log.Fatal(err)
+			}
+			return obj
+		}
+	}
+	return nil
+}
+
+func loadModels(smdxDir string) {
+	if !strings.HasSuffix(smdxDir, "/") {
+		smdxDir = smdxDir + "/"
+	}
+	files, err := ioutil.ReadDir(smdxDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, file := range files {
+		if strings.HasPrefix(file.Name(), "smdx_") {
+			smdxFile, err := os.OpenFile(smdxDir+file.Name(), os.O_RDONLY, 0644)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			def, err := smdx.FromXML(smdxFile)
+			if err != nil {
+				smdxFile.Close()
+				log.Fatal(err)
+			}
+			smdxFile.Close()
+
+			if len(def.Models) < 1 {
+				log.Printf("failed to find any models in %s", file.Name())
+				continue
+			} else {
+				for i, _ := range def.Models {
+					smdx.RegisterModel(&def.Models[i])
+				}
+			}
+		}
+	}
+}
+
+func main() {
+	var inType string
+	var inDevice string
+	var inSpeed int
+	var inLayout string
+	var inSlave int
+
+	var outType string
+	var outDevice string
+	var outSpeed int
+	var outLayout string
+	var outSlave int
+
+	var modelsDir string
+
+	flag.StringVar(&inType, "in:type", "xml", "The type of the input address space.")
+	flag.StringVar(&inDevice, "in:device", "", "The device from which the copied address space is read (in:type=modbus-rtu, only).")
+	flag.IntVar(&inSpeed, "in:speed", 38400, "The connection speed for the device specified by in:device.")
+	flag.StringVar(&inLayout, "in:layout", "", "The address layout to be used with the input address space. Empty for the default sunspec layout. Not required for an xml address spaces.")
+	flag.IntVar(&inSlave, "in:slave", 1, "The slave identifier")
+
+	flag.StringVar(&outType, "out:type", "xml", "The type of the output address space.")
+	flag.StringVar(&outDevice, "out:device", "", "The device to which the copied address space is written (out:type=modbus-rtu, only).")
+	flag.IntVar(&outSpeed, "out:speed", 38400, "The connection speed for the write device specified by out:device.")
+	flag.StringVar(&outLayout, "out:layout", "", "The address layout to be used with the output address space. Empty for the default sunspec layout. Not required for an xml address spaces.")
+	flag.IntVar(&outSlave, "out:slave", 1, "The slave identifier")
+
+	flag.StringVar(&modelsDir, "models-dir", "", "The location from which auxiliary models are loaded.")
+
+	flag.Parse()
+
+	var in sunspec.Array
+	var err error
+
+	if modelsDir != "" {
+		loadModels(modelsDir)
+	}
+
+	if inType == "xml" {
+		decoder := xmlencoding.NewDecoder(os.Stdin)
+		elements := &xml.DataElement{}
+		err = decoder.Decode(elements)
+		if err != nil {
+			log.Fatalf("failed to decode: %v", err)
+		}
+		in, err = xml.Open(elements)
+	} else if inType == "modbus-rtu" {
+		inLayoutObj := readLayout(inLayout)
+
+		var client modbusapi.Client
+		var closer func()
+		client, closer, err = openModbus(inDevice, func(handler *modbusapi.RTUClientHandler) {
+			handler.BaudRate = inSpeed
+			handler.SlaveId = byte(inSlave)
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer closer()
+		if inLayoutObj == nil {
+			in, err = modbus.Open(client)
+		} else {
+			in, err = modbus.OpenWithLayout(client, inLayoutObj)
+		}
+	} else {
+		log.Fatalf("invalid input type: %s", inType)
+	}
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	in.Do(func(d sunspec.Device) {
+		d.Do(func(m sunspec.Model) {
+			m.Do(func(b sunspec.Block) {
+				err = b.Read()
+				if err == nil || inType == "xml" {
+					// errors expected on XML reads.
+					return
+				} else {
+					log.Fatal(err)
+				}
+			})
+		})
+	})
+
+	if outType == "xml" {
+		_, outX := xml.CopyArray(in)
+		encode(os.Stdout, outX)
+	} else if outType == "modbus-rtu" {
+		outLayoutObj := readLayout(outLayout)
+		var client modbusapi.Client
+		var closer func()
+		client, closer, err = openModbus(outDevice, func(handler *modbusapi.RTUClientHandler) {
+			handler.BaudRate = outSpeed
+			handler.SlaveId = byte(outSlave)
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer closer()
+		var out sunspec.Array
+		if outLayoutObj == nil {
+			out, err = modbus.Open(client)
+		} else {
+			out, err = modbus.OpenWithLayout(client, outLayoutObj)
+		}
+		if err != nil {
+			log.Fatal(err)
+		}
+		inDevices := in.Collect(sunspec.AllDevices)
+		outDevices := out.Collect(sunspec.AllDevices)
+
+		for i, inDevice := range inDevices {
+			if i >= len(outDevices) {
+				break
+			}
+			outDevice := outDevices[i]
+			inDevice.Do(func(inModel sunspec.Model) {
+				outModel := outDevice.MustModel(inModel.Id())
+				bn := 0
+				inModel.Do(func(b sunspec.Block) {
+					outBlock := outModel.MustBlock(bn)
+					ids := []string{}
+					b.DoScaleFactorsFirst(func(p sunspec.Point) {
+						if p.Error() == nil {
+							outBlock.MustPoint(p.Id()).SetValue(p.Value())
+							ids = append(ids, p.Id())
+						}
+					})
+					b.Write(ids...)
+					bn++
+				})
+			})
+		}
+	}
+}

--- a/impl/array.go
+++ b/impl/array.go
@@ -16,6 +16,16 @@ func (a *array) Do(f func(d sunspec.Device)) {
 	}
 }
 
+func (a *array) Collect(f func(d sunspec.Device) bool) []sunspec.Device {
+	r := []sunspec.Device{}
+	for _, d := range a.devices {
+		if f(d) {
+			r = append(r, d)
+		}
+	}
+	return r
+}
+
 func (a *array) AddDevice(d spi.DeviceSPI) error {
 	a.devices = append(a.devices, d.(*device))
 	return nil

--- a/sunspec.go
+++ b/sunspec.go
@@ -89,7 +89,10 @@ type ScaleFactor int16
 // marker bytes.
 type Array interface {
 	Do(func(d Device)) // Iterate over all the devices.
+	Collect(func(d Device) bool) []Device
 }
+
+var AllDevices = func(d Device) bool { return true }
 
 // A Device is a collection of Models that provides an uniform abstraction of
 // physical devices of various kinds (Modbus, memory, XML documents)
@@ -110,6 +113,8 @@ type Device interface {
 	//     }
 	Collect(func(m Model) bool) []Model
 }
+
+var AllModels = func(m Model) bool { return true }
 
 // A filter that can be used with Device.Collect to select a subset
 // of the models that have the model id specified.

--- a/xml/driver.go
+++ b/xml/driver.go
@@ -243,6 +243,7 @@ func CopyDevice(d sunspec.Device) (sunspec.Device, *DeviceElement) {
 				panic(err)
 			}
 		}
+		dc.AddModel(mc)
 	})
 	return dc, dx
 }

--- a/xml/driver.go
+++ b/xml/driver.go
@@ -250,12 +250,16 @@ func CopyDevice(d sunspec.Device) (sunspec.Device, *DeviceElement) {
 
 func (phys *xmlDriver) Read(b spi.BlockSPI, pointIds ...string) error {
 	errCount := 0
+	var firstError error
 	ba := b.Anchor().(*blockAnchor)
 	if points, err := b.Plan(pointIds...); err != nil {
 		return err
 	} else {
 		for _, p := range points {
 			recordError := func(e error) {
+				if firstError == nil {
+					firstError = e
+				}
 				p.SetError(e)
 				errCount++
 				// log.Printf("point error: id=%s: %v", p.Id(), e)
@@ -303,7 +307,7 @@ func (phys *xmlDriver) Read(b spi.BlockSPI, pointIds ...string) error {
 		}
 	}
 	if errCount > 0 {
-		return ErrTooManyErrors
+		return firstError
 	} else {
 		return nil
 	}

--- a/xml/driver.go
+++ b/xml/driver.go
@@ -164,18 +164,14 @@ func CopyArray(a sunspec.Array) (sunspec.Array, *DataElement) {
 		Version: "1",
 	}
 
-	devices := []spi.DeviceSPI{}
 	a.Do(func(d sunspec.Device) {
 		da, dx := CopyDevice(d)
 		x.Devices = append(x.Devices, dx)
-		devices = append(devices, da.(spi.DeviceSPI))
-	})
-	for _, c := range devices {
-		if err := arr.AddDevice(c.(spi.DeviceSPI)); err != nil {
+		if err := arr.AddDevice(da.(spi.DeviceSPI)); err != nil {
 			// we are not expecting this to happen
 			panic(err)
 		}
-	}
+	})
 	return arr, x
 }
 

--- a/xml/driver_test.go
+++ b/xml/driver_test.go
@@ -188,3 +188,32 @@ func TestImplicitModel1(t *testing.T) {
 	})
 
 }
+
+func TestXmlOpen(t *testing.T) {
+	buffer := bytes.NewBuffer([]byte(example))
+	data, err := parseXML(buffer)
+	if err != nil {
+		t.Fatal("could not parse example", err.Error())
+	}
+	if x, err := Open(data); err != nil {
+		t.Fatal(err)
+	} else {
+		x.Do(func(d sunspec.Device) {
+			d.Do(func(m sunspec.Model) {
+				m.Do(func(b sunspec.Block) {
+					_ = b.Read()
+				})
+			})
+		})
+		c, cx := CopyArray(x)
+		c.Do(func(d sunspec.Device) {
+			_ = d.MustModel(101)
+		})
+		if cx.Devices[0].Models[1].Id != 101 {
+			t.Fatalf("unexpected id found")
+		}
+		if len(cx.Devices[0].Models[1].Points) != 15 {
+			t.Fatalf("not enough points: %d", len(cx.Devices[0].Models[1].Points))
+		}
+	}
+}


### PR DESCRIPTION
sunspecio is a command that can copy an XML document containing a partial description of one or more SunSpec devices into a modbus-rtu address space or alternatively copy can entire Modbus RTU address space into an XML document.

This series also extends the xml package with an additional test and fixes a bug revealed by that test. 