### PR TITLE
generator: permit generators to run against a different source of SMDX.

### DIFF
--- a/generators/models.go
+++ b/generators/models.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"github.com/crabmusket/gosunspec/smdx"
 	"io/ioutil"
@@ -95,7 +96,11 @@ import (
 
 func main() {
 
-	smdxDir := "../spec/smdx/"
+	var smdxDir string
+
+	flag.StringVar(&smdxDir, "smdx-dir", "../spec/smdx/", "The location of the SMDX directory")
+	flag.Parse()
+
 	files, err := ioutil.ReadDir(smdxDir)
 	if err != nil {
 		log.Fatal(err)

--- a/models/models.go
+++ b/models/models.go
@@ -1,4 +1,4 @@
 package models
 
-//go:generate -command models go run ../generators/models.go
+//go:generate -command models go run ../generators/models.go --smdx-dir=../spec/smdx/
 //go:generate models


### PR DESCRIPTION
The use case is to allow the generators to be used to generate a model
package for SMDX files provided by third parties, for example when marking
up non-Sunspec address spaces for use with a raw layout.

Signed-off-by: Jon Seymour <jon@wildducktheories.com>