### PR TITLE
Respect the modbus RTU length.

### DIFF
--- a/modbus/runbuilder.go
+++ b/modbus/runbuilder.go
@@ -7,20 +7,23 @@ import (
 // runBuilder breaks a sequence of points into a sequence of runs, where each run
 // of points is strictly adjacent
 type runBuilder struct {
-	runs [][]spi.PointSPI
-	run  []spi.PointSPI
+	runs    [][]spi.PointSPI
+	lengths []uint16
+	run     []spi.PointSPI
 }
 
 func newRunBuilder() *runBuilder {
 	run := []spi.PointSPI{}
 	return &runBuilder{
-		run:  run,
-		runs: [][]spi.PointSPI{run},
+		run:     run,
+		lengths: []uint16{0},
+		runs:    [][]spi.PointSPI{run},
 	}
 }
 
 func (r *runBuilder) spawn(p spi.PointSPI) {
 	r.run = []spi.PointSPI{p}
+	r.lengths = append(r.lengths, p.Length())
 	r.runs = append(r.runs, r.run)
 
 }
@@ -37,10 +40,16 @@ func (r *runBuilder) adjacent(p spi.PointSPI) bool {
 func (r *runBuilder) extend(p spi.PointSPI) {
 	r.run = append(r.run, p)
 	r.runs[len(r.runs)-1] = r.run
+	r.lengths[len(r.runs)-1] += p.Length()
+}
+
+func (r *runBuilder) isfull(p spi.PointSPI) bool {
+	// don't excude a limit imposed by the modbus RTU
+	return r.lengths[len(r.lengths)-1]+p.Length() > 125
 }
 
 func (r *runBuilder) add(p spi.PointSPI) {
-	if r.adjacent(p) {
+	if r.adjacent(p) && !r.isfull(p) {
 		r.extend(p)
 	} else {
 		r.spawn(p)


### PR DESCRIPTION
The modbus API does not accept requests for more than 125 registers
due to constraints imposed by the RTU framing specificatiom. So,
we need to break any requests for more than 125 registers into requests
for smaller numbers of registers. The runbuilder is modified to keep track
of total run length.

Signed-off-by: Jon Seymour <jon@wildducktheories.com>