### PR TITLE
xml fixes

### DIFF
--- a/xml/driver.go
+++ b/xml/driver.go
@@ -257,7 +257,7 @@ func (phys *xmlDriver) Read(b spi.BlockSPI, pointIds ...string) error {
 	} else {
 		for _, p := range points {
 			recordError := func(e error) {
-				if firstError == nil {
+				if firstError == nil || firstError == ErrNoSuchElement {
 					firstError = e
 				}
 				p.SetError(e)

--- a/xml/driver.go
+++ b/xml/driver.go
@@ -7,8 +7,10 @@ import (
 	"github.com/crabmusket/gosunspec/models/model1"
 	"github.com/crabmusket/gosunspec/smdx"
 	"github.com/crabmusket/gosunspec/spi"
+	"github.com/crabmusket/gosunspec/typelabel"
 	_ "log"
 	"strconv"
+	"strings"
 )
 
 type blockAnchor struct {
@@ -248,6 +250,16 @@ func CopyDevice(d sunspec.Device) (sunspec.Device, *DeviceElement) {
 	return dc, dx
 }
 
+func deriveScaleFactor(v string, sf int16) (string, sunspec.ScaleFactor) {
+	pos := strings.Index(v, ".")
+	if pos < 0 {
+		return v, sunspec.ScaleFactor(sf)
+	} else {
+		// "1.3", pos=1, len=3 -> 1-3+1 -> 2-3 -> -1
+		return strings.Replace(v, ".", "", 1), sunspec.ScaleFactor(pos - len(v) + 1)
+	}
+}
+
 func (phys *xmlDriver) Read(b spi.BlockSPI, pointIds ...string) error {
 	errCount := 0
 	var firstError error
@@ -278,7 +290,8 @@ func (phys *xmlDriver) Read(b spi.BlockSPI, pointIds ...string) error {
 			sfp := p.ScaleFactorPoint()
 			v := px.Value
 			if sfp != nil {
-				vsf := sunspec.ScaleFactor(px.ScaleFactor)
+				var vsf sunspec.ScaleFactor
+				v, vsf = deriveScaleFactor(v, px.ScaleFactor)
 				if sfp.Error() != nil {
 					sfp.SetScaleFactor(vsf)
 				}

--- a/xml/driver.go
+++ b/xml/driver.go
@@ -271,7 +271,7 @@ func (phys *xmlDriver) Read(b spi.BlockSPI, pointIds ...string) error {
 				continue
 			}
 			px := ba.model.Points[pa.position]
-			if len(px.Value) == 0 {
+			if len(px.Value) == 0 && p.Type() != typelabel.String {
 				recordError(ErrEmptyValue)
 				continue
 			}

--- a/xml/driver_test.go
+++ b/xml/driver_test.go
@@ -201,7 +201,10 @@ func TestXmlOpen(t *testing.T) {
 		x.Do(func(d sunspec.Device) {
 			d.Do(func(m sunspec.Model) {
 				m.Do(func(b sunspec.Block) {
-					_ = b.Read()
+					err = b.Read()
+					if err != ErrNoSuchElement {
+						t.Fatal(err)
+					}
 				})
 			})
 		})

--- a/xml/driver_test.go
+++ b/xml/driver_test.go
@@ -215,8 +215,8 @@ func TestXmlOpen(t *testing.T) {
 		if cx.Devices[0].Models[1].Id != 101 {
 			t.Fatalf("unexpected id found")
 		}
-		if len(cx.Devices[0].Models[1].Points) != 15 {
-			t.Fatalf("not enough points: %d", len(cx.Devices[0].Models[1].Points))
+		if len(cx.Devices[0].Models[1].Points) != 19 {
+			t.Fatalf("point mismatch points: %d", len(cx.Devices[0].Models[1].Points))
 		}
 	}
 }

--- a/xml/main_test.go
+++ b/xml/main_test.go
@@ -20,7 +20,7 @@ const example = `
 			<p id="A" sf="-2">3043</p>
 			<p id="PhVphA">2216</p>
 			<p id="V_SF">-1</p>
-			<p id="W" u="Watts">6701.3</p>
+			<p id="W" u="Watts">6501.3</p>
 			<p id="Hz">60.01</p>
 			<p id="WH">126973</p>
 			<p id="DCA">14.28</p>

--- a/xml/main_test.go
+++ b/xml/main_test.go
@@ -13,6 +13,9 @@ import (
 const example = `
 <SunSpecData v="1">
 	<d ns="mac" lid="11:22:33:44:55:66" man="gsc" mod="r300" sn="123456" t="2011-05-12T09:21:49Z" cid="2">
+		<m id="1">
+			<p id="Mn"></p> 
+		</m>
 		<m id="101" x="1">
 			<p id="A" sf="-2">3043</p>
 			<p id="PhVphA">2216</p>
@@ -43,22 +46,22 @@ func TestXmlParse(t *testing.T) {
 	if len(data0.Devices) != 1 {
 		t.Fatal("wrong number of devices found")
 	}
-	if len(data0.Devices[0].Models) != 1 {
+	if len(data0.Devices[0].Models) != 2 {
 		t.Fatal("wrong number of models found")
 	}
-	if len(data0.Devices[0].Models[0].Points) != 11 {
+	if len(data0.Devices[0].Models[1].Points) != 11 {
 		t.Fatal("wrong number of points found")
 	}
-	if id := data0.Devices[0].Models[0].Points[0].Id; id != "A" {
+	if id := data0.Devices[0].Models[1].Points[0].Id; id != "A" {
 		t.Error("wrong id in first point:", id)
 	}
-	if value := data0.Devices[0].Models[0].Points[0].Value; value != "3043" {
+	if value := data0.Devices[0].Models[1].Points[0].Value; value != "3043" {
 		t.Error("wrong value in first point:", value)
 	}
-	if scale := data0.Devices[0].Models[0].Points[0].ScaleFactor; scale != -2 {
+	if scale := data0.Devices[0].Models[1].Points[0].ScaleFactor; scale != -2 {
 		t.Error("wrong scale factor in first point:", scale)
 	}
-	if units := data0.Devices[0].Models[0].Points[3].Unit; units != "Watts" {
+	if units := data0.Devices[0].Models[1].Points[3].Unit; units != "Watts" {
 		t.Error("wrong units in third point:", units)
 	}
 }


### PR DESCRIPTION
This series fixes some issues in the handling of XML documents:

- tolerate empty strings
- derive implicit scale factors from strings of the form 6501.3
- fix a test so that it doesn't hide read errors
- ensure that boring errors (ErrNoSuchElement) don't hide interesting ones
- fix a test so that it doesn't use a value that is too large to encode.
 
