### PR TITLE
modbus: abort scan of slave address space upon first timeout.

### DIFF
--- a/layout/layout.go
+++ b/layout/layout.go
@@ -12,6 +12,7 @@ const (
 var (
 	ErrNotSunspecDevice = errors.New("not a SunSpec device") // if the Modbus address space doesn't contain the expected marker bytes
 	ErrShortRead        = errors.New("short read")           // if an attempt to read from the Modbus addess space returns fewer bytes than expected
+	ErrTimeout          = errors.New("timeout")              // if a timeout occurred
 )
 
 // AddressSpaceDriver abstracts the behaviour of drivers that are mapped onto a linear address space,

--- a/layout/sunspec.go
+++ b/layout/sunspec.go
@@ -23,6 +23,11 @@ func (s *SunSpecLayout) Open(a AddressSpaceDriver) (spi.ArraySPI, error) {
 	base := uint16(0xffff)
 	for _, b := range baseRange {
 		if id, err := a.ReadWords(b, 2); err != nil {
+			if err == ErrTimeout {
+				// if one query fails with a timeout, then assume
+				// they all will.
+				return nil, err
+			}
 			continue
 		} else if binary.BigEndian.Uint32(id) != SunSpec {
 			continue

--- a/modbus/modbus.go
+++ b/modbus/modbus.go
@@ -6,6 +6,7 @@ import (
 	"github.com/crabmusket/gosunspec/layout"
 	"github.com/crabmusket/gosunspec/spi"
 	"github.com/goburrow/modbus"
+	"github.com/goburrow/serial"
 )
 
 const (
@@ -33,8 +34,17 @@ type modbusDriver struct {
 	client modbus.Client
 }
 
+func mapError(err error) error {
+	if err == serial.ErrTimeout {
+		return layout.ErrTimeout
+	} else {
+		return err
+	}
+}
+
 func (m *modbusDriver) ReadWords(address uint16, length uint16) ([]byte, error) {
-	return m.client.ReadHoldingRegisters(address, length)
+	b, err := m.client.ReadHoldingRegisters(address, length)
+	return b, mapError(err)
 }
 
 func (m *modbusDriver) BaseOffsets() []uint16 {


### PR DESCRIPTION
This helps to reduce the time spent waiting on timeouts for missing slave devices.

Signed-off-by: Jon Seymour <jon@wildducktheories.com>