### PR TITLE
Add handling of unimplemented points

### DIFF
--- a/impl/impl_test.go
+++ b/impl/impl_test.go
@@ -1,7 +1,7 @@
 package impl
 
 import (
-	"encoding/binary"
+	"bytes"
 	"math"
 	"testing"
 
@@ -25,8 +25,8 @@ func TestCompleteArray(t *testing.T) {
 
 func TestNotImplemented(t *testing.T) {
 	cases := []struct {
-		e bool
-		v interface{}
+		expect bool
+		value interface{}
 	}{
 		{false, float32(0)},
 		{true, math.Float32frombits(0x7fc00000)},
@@ -47,7 +47,7 @@ func TestNotImplemented(t *testing.T) {
 		{true, sunspec.Ipaddr{0, 0, 0, 0}},
 		{true, sunspec.Ipv6addr{0, 0, 0, 0, 0, 0}},
 		{false, sunspec.Eui48{0, 0, 0, 0, 0, 0}},
-		{true, sunspec.Eui48{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}},
+		{true, sunspec.Eui48{0x01, 0x02, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}},
 		{false, sunspec.Bitfield16(0)},
 		{false, sunspec.Bitfield32(0)},
 		{true, sunspec.Bitfield16(0xFFFF)},
@@ -61,11 +61,11 @@ func TestNotImplemented(t *testing.T) {
 	for _, c := range cases {
 		p := point{
 			err:   nil,
-			value: c.v,
+			value: c.value,
 		}
 
-		if c.e != p.NotImplemented() {
-			t.Errorf("expected %v, got %v", c.e, c.v)
+		if exp:=p.NotImplemented(); c.expect !=  exp{
+			t.Errorf("expected %v, got %v for %v", c.expect, exp, c.value)
 		}
 
 		if v, ok := p.Value().(sunspec.NotImplemented); !ok {
@@ -85,7 +85,7 @@ func TestMarshalEui48(t *testing.T) {
 	p.Unmarshal([]byte{1, 2, 3, 4, 5, 6, 7, 8})
 
 	v := p.Value().(sunspec.Eui48)
-	if binary.BigEndian.Uint64(v[:]) != 0x0102030405060708 {
+	if !bytes.Equal(v[:], []byte{1, 2, 3, 4, 5, 6, 7, 8}){
 		t.Errorf("unexpected value result, got %v", v)
 	}
 

--- a/impl/point.go
+++ b/impl/point.go
@@ -90,6 +90,80 @@ func (p *point) Length() uint16 {
 	}
 }
 
+// NotImplemented validates if the actual value matches any of the
+// unimplemented values according to the specification. In this case
+// it will return true. NotImplemented can be used to check if the
+// results returned by any of the getter functions is valid.
+func (p *point) NotImplemented() bool {
+	p.checkerror()
+
+	notImplemented := false
+	switch v := p.value.(type) {
+	case float32:
+		if 0x7fc00000 == math.Float32bits(v) {
+			notImplemented = true
+		}
+	case int16:
+		if v == int16(math.MinInt16) {
+			notImplemented = true
+		}
+	case int32:
+		if v == int32(math.MinInt32) {
+			notImplemented = true
+		}
+	case int64:
+		if v == int64(math.MinInt64) {
+			notImplemented = true
+		}
+	case uint16:
+		if v == uint16(math.MaxUint16) {
+			notImplemented = true
+		}
+	case uint32:
+		if v == uint32(math.MaxUint32) {
+			notImplemented = true
+		}
+	case uint64:
+		if v == uint64(math.MaxUint64) {
+			notImplemented = true
+		}
+	case sunspec.Enum16:
+		if uint16(v) == uint16(math.MaxUint16) {
+			notImplemented = true
+		}
+	case sunspec.Enum32:
+		if uint32(v) == uint32(math.MaxUint32) {
+			notImplemented = true
+		}
+	case sunspec.Bitfield16:
+		if uint16(v) == uint16(math.MaxUint16) {
+			notImplemented = true
+		}
+	case sunspec.Bitfield32:
+		if uint32(v) == uint32(math.MaxUint32) {
+			notImplemented = true
+		}
+	case sunspec.Ipaddr:
+		// 4 bytes
+		if binary.BigEndian.Uint32(v[0:]) == 0 {
+			notImplemented = true
+		}
+	case sunspec.Ipv6addr:
+		// 2x8 bytes
+		if binary.BigEndian.Uint64(v[0:]) == 0 && binary.BigEndian.Uint64(v[8:]) == 0 {
+			notImplemented = true
+		}
+	case sunspec.Eui48:
+		// 4+2 bytes
+		if binary.BigEndian.Uint32(v[0:]) == uint32(math.MaxUint32) &&
+			binary.BigEndian.Uint16(v[4:]) == uint16(math.MaxUint16) {
+			notImplemented = true
+		}
+	}
+
+	return notImplemented
+}
+
 // Scales the point value with the associated scaling factor,
 // if any, returning a float64 value.
 func (p *point) ScaledValue() float64 {
@@ -119,6 +193,12 @@ func (p *point) ScaledValue() float64 {
 	default:
 		panic(fmt.Errorf("attempt to use non-numeric value as scaled value: point=%s", p.Id()))
 	}
+
+	// Unimplemented value
+	if p.NotImplemented() {
+		return math.NaN()
+	}
+
 	sf := sunspec.ScaleFactor(0)
 	if p.scaleFactor != nil {
 		sf = p.scaleFactor.ScaleFactor()
@@ -127,12 +207,21 @@ func (p *point) ScaledValue() float64 {
 			sf = sunspec.ScaleFactor(v)
 		}
 	}
+
+	// Unimplemented scale factor value
+	if int16(sf) == int16(math.MinInt16) {
+		return math.NaN()
+	}
+
 	return f * math.Pow(10, float64(sf))
 }
 
 // The value of the point, without regard to its actual type.
 func (p *point) Value() interface{} {
 	p.checkerror()
+	if p.NotImplemented() {
+		return sunspec.NotImplemented(struct{}{})
+	}
 	return p.value
 }
 

--- a/impl/point.go
+++ b/impl/point.go
@@ -1,6 +1,7 @@
 package impl
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -150,17 +151,16 @@ func (p *point) NotImplemented() bool {
 		}
 	case sunspec.Ipv6addr:
 		// 2x8 bytes
-		if binary.BigEndian.Uint64(v[0:]) == 0 && binary.BigEndian.Uint64(v[8:]) == 0 {
+		if bytes.Equal(v[:], []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}) {
 			notImplemented = true
 		}
 	case sunspec.Eui48:
-		// 4+2 bytes
-		if binary.BigEndian.Uint32(v[0:]) == uint32(math.MaxUint32) &&
-			binary.BigEndian.Uint16(v[4:]) == uint16(math.MaxUint16) {
+		// 6 bytes starting at 2
+		if bytes.Equal(v[2:], []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}) {
 			notImplemented = true
 		}
 	case sunspec.ScaleFactor:
-		if int16(v) == int16(math.MinInt16) {
+		if v == sunspec.ScaleFactor(math.MinInt16) {
 			notImplemented = true
 		}
 	}

--- a/impl/point.go
+++ b/impl/point.go
@@ -159,6 +159,10 @@ func (p *point) NotImplemented() bool {
 			binary.BigEndian.Uint16(v[4:]) == uint16(math.MaxUint16) {
 			notImplemented = true
 		}
+	case sunspec.ScaleFactor:
+		if int16(v) == int16(math.MinInt16) {
+			notImplemented = true
+		}
 	}
 
 	return notImplemented

--- a/sunspec.go
+++ b/sunspec.go
@@ -77,6 +77,9 @@ type Ipv6addr [16]byte
 // A 16-bit pad register. Always 0x8000.
 type Pad uint16
 
+// An unimplemented point's value
+type NotImplemented interface{}
+
 // A 16-bit scaling factor used to scale the value of some other integer register.
 type ScaleFactor int16
 
@@ -309,12 +312,23 @@ type Point interface {
 	SetUint32(v uint32)
 	SetUint64(v uint64)
 
+	// NotImplemented validates if the value is unimplemented according to
+	// the specification. It can be used to check if the results
+	// returned by any of the getter functions is valid.
+	// This function does not- for sake of simplicity- validate Acc16/32/64
+	// and String types. These can be checked via their natural zero value.
+	NotImplemented() bool
+
 	// Answer the scaled value of the point as a float64. This method
 	// will panic if the Error() method of either the point or the
 	// related scaling factor is not nil.
+	// ScaledValue() checks for unimplemented values using NotImplemented()
+	// and returns NaN in this case.
 	ScaledValue() float64
 
 	// Answer the value of the point. This method will panic if Error() is not nil.
+	// Value checks for unimplemented values using NotImplemented()
+	// and returns the NotImplemented type in this case.
 	Value() interface{}
 
 	// Set the value associated with the point. This method will panic if the value


### PR DESCRIPTION
Fixes #33. 

BC break as behaviour changes. Might make sense to *only* apply this to `ScaledValue` instead of `Value`, too to limit the impact.

Open:

  - [x] Fix `Eui48` to take #39 into account