### PR TITLE
Make point to string conversion available on base types

### DIFF
--- a/impl/point.go
+++ b/impl/point.go
@@ -522,43 +522,18 @@ func (p *point) MarshalXML() string {
 		panic(p.err)
 	}
 	switch p.Type() {
-	case typelabel.Bitfield16, typelabel.Pad:
-		return fmt.Sprintf("0x%04x", p.value)
+	case typelabel.Bitfield16:
+		return p.Bitfield16().String()
 	case typelabel.Bitfield32:
-		return fmt.Sprintf("0x%08x", p.value)
+		return p.Bitfield32().String()
+	case typelabel.Pad:
+		return p.Pad().String()
 	case typelabel.Ipaddr:
-		buf := []byte{}
-		for x, b := range p.Ipaddr() {
-			if x != 0 {
-				buf = append(buf, '.')
-			}
-			buf = append(buf, fmt.Sprintf("%d", b)...)
-		}
-		return string(buf)
+		return p.Ipaddr().String()
 	case typelabel.Ipv6addr:
-		buf := []byte{}
-		in := p.Ipv6addr()
-		for x, _ := range in {
-			if x%2 == 1 {
-				continue
-			}
-			if x != 0 {
-				buf = append(buf, ':')
-			}
-			buf = append(buf, fmt.Sprintf("%04x", uint16(in[x])<<8|uint16(in[x+1]))...)
-		}
-		return string(buf)
+		return p.Ipv6addr().String()
 	case typelabel.Eui48:
-		buf := []byte{}
-		eui48 := p.Eui48()
-		// first word is unused - ignore
-		for x, b := range eui48[2:] {
-			if x != 0 {
-				buf = append(buf, ':')
-			}
-			buf = append(buf, fmt.Sprintf("%02x", b)...)
-		}
-		return string(buf)
+		return p.Eui48().String()
 	default:
 		return fmt.Sprintf("%v", p.value)
 	}

--- a/stringer.go
+++ b/stringer.go
@@ -1,0 +1,51 @@
+package sunspec
+
+import "fmt"
+
+func (p Eui48) String() string {
+	buf := []byte{}
+	for x, b := range p {
+		if x != 0 {
+			buf = append(buf, ':')
+		}
+		buf = append(buf, fmt.Sprintf("%02x", b)...)
+	}
+	return string(buf)
+}
+
+func (p Ipaddr) String() string {
+	buf := []byte{}
+	for x, b := range p {
+		if x != 0 {
+			buf = append(buf, '.')
+		}
+		buf = append(buf, fmt.Sprintf("%d", b)...)
+	}
+	return string(buf)
+}
+
+func (p Ipv6addr) String() string {
+	buf := []byte{}
+	for x := range p {
+		if x%2 == 1 {
+			continue
+		}
+		if x != 0 {
+			buf = append(buf, ':')
+		}
+		buf = append(buf, fmt.Sprintf("%04x", uint16(in[x])<<8|uint16(in[x+1]))...)
+	}
+	return string(buf)
+}
+
+func (p Bitfield16) String() string {
+	return fmt.Sprintf("0x%04x", p.value)
+}
+
+func (p Bitfield32) String() string {
+	return fmt.Sprintf("0x%08x", p.value)
+}
+
+func (p Pad) String() string {
+	return fmt.Sprintf("0x%04x", p.value)
+}

--- a/stringer.go
+++ b/stringer.go
@@ -4,7 +4,7 @@ import "fmt"
 
 func (p Eui48) String() string {
 	buf := []byte{}
-	for x, b := range p {
+	for x, b := range p[2:] {
 		if x != 0 {
 			buf = append(buf, ':')
 		}
@@ -33,19 +33,19 @@ func (p Ipv6addr) String() string {
 		if x != 0 {
 			buf = append(buf, ':')
 		}
-		buf = append(buf, fmt.Sprintf("%04x", uint16(in[x])<<8|uint16(in[x+1]))...)
+		buf = append(buf, fmt.Sprintf("%04x", uint16(p[x])<<8|uint16(p[x+1]))...)
 	}
 	return string(buf)
 }
 
 func (p Bitfield16) String() string {
-	return fmt.Sprintf("0x%04x", p.value)
+	return fmt.Sprintf("0x%04x", uint16(p))
 }
 
 func (p Bitfield32) String() string {
-	return fmt.Sprintf("0x%08x", p.value)
+	return fmt.Sprintf("0x%08x", uint32(p))
 }
 
 func (p Pad) String() string {
-	return fmt.Sprintf("0x%04x", p.value)
+	return fmt.Sprintf("0x%04x", uint16(p))
 }

--- a/stringer_test.go
+++ b/stringer_test.go
@@ -1,0 +1,52 @@
+package sunspec
+
+import (
+	"testing"
+)
+
+func TestEui48(t *testing.T) {
+	p := Eui48{1, 2, 3, 4, 5, 6, 7, 8}
+
+	if v := p.String(); v != "03:04:05:06:07:08" {
+		t.Errorf("unexpected result, got %v", v)
+	}
+}
+
+func TestIpaddr(t *testing.T) {
+	p := Ipaddr{1, 2, 3, 4}
+
+	if v := p.String(); v != "1.2.3.4" {
+		t.Errorf("unexpected result, got %v", v)
+	}
+}
+
+func TestIpv6addr(t *testing.T) {
+	p := Ipv6addr{1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8}
+
+	if v := p.String(); v != "0102:0304:0506:0708:0102:0304:0506:0708" {
+		t.Errorf("unexpected result, got %v", v)
+	}
+}
+
+func TestBitfield16(t *testing.T) {
+	p := Bitfield16(0x1234)
+
+	if v := p.String(); v != "0x1234" {
+		t.Errorf("unexpected result, got %v", v)
+	}
+}
+
+func TestBitfield32(t *testing.T) {
+	p := Bitfield32(0x12345678)
+
+	if v := p.String(); v != "0x12345678" {
+		t.Errorf("unexpected result, got %v", v)
+	}
+}
+
+func TestPad(t *testing.T) {
+	p := Pad(0x1234)
+
+	if v := p.String(); v != "0x1234" {
+		t.Errorf("unexpected result, got %v", v)
+	}}


### PR DESCRIPTION
The idea is to make standard conversions available to library consumers. Right now they’d need to provide their own implementation.

This could obviously use some tests....