### PR TITLE
Fix test case for 8 byte eui48

### DIFF
--- a/memory/data.go
+++ b/memory/data.go
@@ -1,7 +1,7 @@
 package memory
 
 import (
-	"github.com/crabmusket/gosunspec"
+	sunspec "github.com/crabmusket/gosunspec"
 	"github.com/crabmusket/gosunspec/models/model101"
 	"github.com/crabmusket/gosunspec/models/model11"
 	"github.com/crabmusket/gosunspec/models/model304"
@@ -39,7 +39,7 @@ var (
 	CONST_FLOAT32  = float32(100.02)
 	CONST_IP       = sunspec.Ipaddr{127, 0, 0, 1}
 	CONST_IPV6     = sunspec.Ipv6addr{0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00}
-	CONST_EUI48    = sunspec.Eui48{0, 1, 2, 3, 4, 5}
+	CONST_EUI48    = sunspec.Eui48{0, 0, 2, 3, 4, 5, 6, 7}
 	ExpectedValues = map[string]interface{}{
 		typelabel.Acc16:       CONST_ACC16,
 		typelabel.Acc32:       CONST_ACC32,


### PR DESCRIPTION
This is required as the first 2 bytes are ignored. It becomes obvious that the 8 byte implementation in #39 has its drawback. While it can serialize/inserialize without loss of the first word, clients using it need to adjust semantics.

To avoid client-side interpretation of the sunspec spec #41 helps to lessen the pain.

For time being this corrects the change but we may need to revisit the design decision.