### PR TITLE
Include partial model result in case of error

### DIFF
--- a/layout/sunspec.go
+++ b/layout/sunspec.go
@@ -2,11 +2,12 @@ package layout
 
 import (
 	"encoding/binary"
+	"log"
+
 	"github.com/crabmusket/gosunspec/impl"
 	"github.com/crabmusket/gosunspec/models/model1"
 	"github.com/crabmusket/gosunspec/smdx"
 	"github.com/crabmusket/gosunspec/spi"
-	"log"
 )
 
 // SunspecLayout is the type of layout that understands the SunSpec layout conventions.
@@ -49,6 +50,9 @@ func (s *SunSpecLayout) Open(a AddressSpaceDriver) (spi.ArraySPI, error) {
 	offset := uint16(2) // number of 16 bit registers
 	for {
 		if bytes, err := a.ReadWords(base+offset, 2); err != nil {
+			if offset > 2 { // model chain partially available
+				return array, err
+			}
 			return nil, err
 		} else if len(bytes) < 4 {
 			return nil, ErrShortRead


### PR DESCRIPTION
This PR is addressing an edge case. I've noticed Kostal PLENTICORE fail to read 2 words after end of the model chain. 
To allow library consumers to realize this and act accordingly I'm suggesting to return the partial model (instead of nil) plus error under the condition that any model details have been read sofar. Consumer can then decide- given that error is still signaled- if the returned partial model chain is acceptable.
